### PR TITLE
Wrong http error code when providing wrong credentials at log in

### DIFF
--- a/app/controllers/api/UsersController.js
+++ b/app/controllers/api/UsersController.js
@@ -29,7 +29,7 @@ function UsersController() {
 				break;
 			case('ValidationError'):
 				errorMessage = "Invalid email OR password input";
-				statusCode = 402;
+				statusCode = 401;
 				break;
 			case('InvalidToken'):
 				errorMessage = 'Invalid token or token expired';


### PR DESCRIPTION
Changed login error when providing wrong credentials from 402(payment required) to 401(Not authorized).